### PR TITLE
Fix to properly support graylog 2.0

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -76,7 +76,7 @@ type GelfMessage struct {
 	Timestamp    float64 `json:"timestamp,omitempty"`
 	Level        int     `json:"level,omitempty"`
 
-	ContainerId    string `json:"_docker.container,omitempty"`
-	ContainerImage string `json:"_docker.image,omitempty"`
-	ContainerName  string `json:"_docker.name,omitempty"`
+	ContainerId    string `json:"docker_container,omitempty"`
+	ContainerImage string `json:"docker_image,omitempty"`
+	ContainerName  string `json:"docker_name,omitempty"`
 }


### PR DESCRIPTION
Due to changes in elasticsearch, dots should no longer be used in GL 2.0.  This change is to change the field names from dots to underscores.