### PR TITLE
Updated gelf adapter to use go-gelf.v2

### DIFF
--- a/gelf.go
+++ b/gelf.go
@@ -27,12 +27,15 @@ type GelfAdapter struct {
 
 // NewGelfAdapter creates a GelfAdapter with UDP as the default transport.
 func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
-	_, found := router.AdapterTransports.Lookup(route.AdapterTransport("tcp"))
+	_, found := router.AdapterTransports.Lookup(route.AdapterTransport("udp"))
 	if !found {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}
 
 	gelfWriter, err := gelf.NewWriter(route.Address)
+
+	log.Info(route)
+
 	if err != nil {
 		return nil, err
 	}

--- a/gelf.go
+++ b/gelf.go
@@ -3,12 +3,13 @@ package gelf
 import (
 	"encoding/json"
 	"errors"
-	"github.com/Graylog2/go-gelf/gelf"
-	"github.com/gliderlabs/logspout/router"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Graylog2/go-gelf/gelf"
+	"github.com/gliderlabs/logspout/router"
 )
 
 var hostname string
@@ -26,7 +27,7 @@ type GelfAdapter struct {
 
 // NewGelfAdapter creates a GelfAdapter with UDP as the default transport.
 func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
-	_, found := router.AdapterTransports.Lookup(route.AdapterTransport("udp"))
+	_, found := router.AdapterTransports.Lookup(route.AdapterTransport("tcp"))
 	if !found {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}

--- a/gelf.go
+++ b/gelf.go
@@ -21,7 +21,7 @@ func init() {
 
 // GelfAdapter is an adapter that streams UDP JSON to Graylog
 type GelfAdapter struct {
-	writer      *gelf.GelfWriter
+	//	writer      *gelf.GelfWriter
 	route       *router.Route
 	adapterType string
 }
@@ -30,8 +30,9 @@ type GelfAdapter struct {
 func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	// Identify adatper type to use later for building the write //
-	routeAdapterType := route.AdapterType
+	routeAdapterType := route.AdapterType()
 	_, found := router.AdapterTransports.Lookup(route.AdapterTransport(routeAdapterType))
+
 	if !found {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}
@@ -41,13 +42,9 @@ func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	log.Println(route)
 
-	if err != nil {
-		return nil, err
-	}
-
 	return &GelfAdapter{
-		route:       route,
-		writer:      gelfWriter,
+		route: route,
+		//	writer:      gelfWriter,
 		adapterType: routeAdapterType,
 	}, nil
 }
@@ -87,13 +84,13 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 		if a.adapterType == "tcp" {
 			// Create and Stream using TCP Writer
 			newWriter, err := gelf.NewTCPWriter(route.Address)
-			newWriter.GelfWriter = a.Writer
+			//newWriter.GelfWriter = a.Writer
 			checkError(err)
 			sendMessage(newWriter, &msg)
 		} else if a.adapterType == "udp" {
 			// Create and Stream using the UDP Writer
 			newWriter, err := gelf.NewUDPWriter(route.Address)
-			newWriter.GelfWriter = a.Writer
+			//newWriter.GelfWriter = a.Writer
 			checkError(err)
 			sendMessage(newWriter, &msg)
 		} else {

--- a/gelf.go
+++ b/gelf.go
@@ -83,20 +83,19 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 
 		if a.adapterType == "tcp" {
 			// Create and Stream using TCP Writer
-			newWriter, err := gelf.NewTCPWriter(route.Address)
+			newWriter, err := gelf.NewTCPWriter(a.route.Address)
 			//newWriter.GelfWriter = a.Writer
 			checkError(err)
 			sendMessage(newWriter, &msg)
 		} else if a.adapterType == "udp" {
 			// Create and Stream using the UDP Writer
-			newWriter, err := gelf.NewUDPWriter(route.Address)
+			newWriter, err := gelf.NewUDPWriter(a.route.Address)
 			//newWriter.GelfWriter = a.Writer
 			checkError(err)
 			sendMessage(newWriter, &msg)
 		} else {
 			// TLS is not supported so ignore message
 			log.Println("Gelf Adapter: tls is not yet support")
-			continue
 		}
 
 		/*if err := a.writer.WriteMessage(&msg); err != nil {
@@ -114,12 +113,10 @@ func checkError(err error) {
 }
 
 // Wrapper implementing the interface //
-func sendMessage(w gelf.Writer, m *message) error {
+func sendMessage(w gelf.Writer, m *gelf.Message) {
 	if err := w.WriteMessage(m); err != nil {
 		log.Println("Graylog:", err)
-		continue
 	}
-
 }
 
 // GelfMessage stores the router Message //

--- a/gelf.go
+++ b/gelf.go
@@ -30,7 +30,7 @@ type GelfAdapter struct {
 func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	// Identify adatper type to use later for building the write //
-	routeAdapterType := route.AdapterType()
+	routeAdapterType := route.AdapterTransport("udp")
 	_, found := router.AdapterTransports.Lookup(route.AdapterTransport(routeAdapterType))
 
 	if !found {
@@ -90,7 +90,7 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 			sendMessage(newWriter, &msg)
 		} else {
 			// TLS is not supported so ignore message
-			log.Println("Gelf Adapter: tls is not yet support")
+			log.Printf("Gelf Adapter: %s is not yet support", a.adapterType)
 		}
 	}
 }

--- a/gelf.go
+++ b/gelf.go
@@ -37,11 +37,6 @@ func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}
 
-	// Will add checks here to identify what protocol is specified in adapter before using it //
-	//gelfWriter, err := gelf.NewTCPWriter(route.Address)
-
-	log.Println(route)
-
 	return &GelfAdapter{
 		route: route,
 		//	writer:      gelfWriter,
@@ -68,7 +63,7 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 			Host:     hostname,
 			Short:    m.Message.Data,
 			TimeUnix: float64(m.Message.Time.UnixNano()/int64(time.Millisecond)) / 1000.0,
-			Level:    level,
+			Level:    int32(level),
 			RawExtra: extra,
 		}
 		// 	ContainerId:    m.Container.ID,
@@ -97,18 +92,12 @@ func (a *GelfAdapter) Stream(logstream chan *router.Message) {
 			// TLS is not supported so ignore message
 			log.Println("Gelf Adapter: tls is not yet support")
 		}
-
-		/*if err := a.writer.WriteMessage(&msg); err != nil {
-			log.Println("Graylog:", err)
-			continue
-		}*/
 	}
 }
 
 func checkError(err error) {
 	if err != nil {
 		log.Println("Graylog:", err)
-		continue
 	}
 }
 

--- a/gelf.go
+++ b/gelf.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Graylog2/go-gelf/gelf"
 	"github.com/gliderlabs/logspout/router"
+	"gopkg.in/Graylog2/go-gelf.v2/gelf"
 )
 
 var hostname string
@@ -32,7 +32,8 @@ func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 		return nil, errors.New("unable to find adapter: " + route.Adapter)
 	}
 
-	gelfWriter, err := gelf.NewWriter(route.Address)
+	// Will add checks here to identify what protocol is specified in adapter before using it //
+	gelfWriter, err := gelf.NewTCPWriter(route.Address)
 
 	log.Println(route)
 

--- a/gelf.go
+++ b/gelf.go
@@ -34,7 +34,7 @@ func NewGelfAdapter(route *router.Route) (router.LogAdapter, error) {
 
 	gelfWriter, err := gelf.NewWriter(route.Address)
 
-	log.Info(route)
+	log.Println(route)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Updated the adapter to use go-gelf.v2 which nows allow adapter to support both UDP and TCP transports for the GELF adaptor.